### PR TITLE
set encoding ASCII-8BIT for Regexp in frame parser

### DIFF
--- a/lib/libwebsocket/frame.rb
+++ b/lib/libwebsocket/frame.rb
@@ -44,7 +44,7 @@ module LibWebSocket
     #   frame.next; # =>  foo
     #   frame.next; # =>  bar
     def next
-      return unless @buffer.slice!(/^[^\x00]*\x00(.*?)\xff/m)
+      return unless @buffer.slice!(/^[^\x00]*\x00(.*?)\xff/nm)
 
       string = $1
       string.force_encoding('UTF-8') if string.respond_to?(:force_encoding)


### PR DESCRIPTION
Hi

I got `invalid multibyte escape` error on Ruby 2.0.0,  so I've fixed it.
I have tested on 1.8.7, 1.9.2, 1.9.3 and 2.0.0.

```
[1/4] TestFrame#test_append = 0.00 s
  1) Error:
test_append(TestFrame):
SyntaxError: /home/sho/src/ruby/libwebsocket/lib/libwebsocket/frame.rb:47: invalid multibyte escape: /^[^\x00]*\x00(.*?)\xff/m
    /home/sho/src/ruby/libwebsocket/test/libwebsocket/test_frame.rb:6:in `test_append'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1301:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit/testcase.rb:17:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:919:in `block in _run_suite'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:912:in `map'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:912:in `_run_suite'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:657:in `block in _run_suites'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:655:in `each'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:655:in `_run_suites'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:867:in `_run_anything'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1060:in `run_tests'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1047:in `block in _run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1046:in `each'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1046:in `_run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1035:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:21:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:774:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:366:in `block (2 levels) in autorun'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:27:in `run_once'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:365:in `block in autorun'

[2/4] TestFrame#test_new = 0.00 s
  2) Error:
test_new(TestFrame):
SyntaxError: /home/sho/src/ruby/libwebsocket/lib/libwebsocket/frame.rb:47: invalid multibyte escape: /^[^\x00]*\x00(.*?)\xff/m
    /home/sho/src/ruby/libwebsocket/test/libwebsocket/test_frame.rb:48:in `test_new'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1301:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit/testcase.rb:17:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:919:in `block in _run_suite'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:912:in `map'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:912:in `_run_suite'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:657:in `block in _run_suites'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:655:in `each'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:655:in `_run_suites'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:867:in `_run_anything'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1060:in `run_tests'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1047:in `block in _run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1046:in `each'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1046:in `_run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/minitest/unit.rb:1035:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:21:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:774:in `run'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:366:in `block (2 levels) in autorun'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:27:in `run_once'
    /home/sho/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/test/unit.rb:365:in `block in autorun'
```
